### PR TITLE
Fix bugs identified in code review

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,27 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      # Publish on any tag starting with a `v`, e.g., v1.2.3
+      - v*
+
+jobs:
+  deploy:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install prerequisites
+        uses: astral-sh/setup-uv@v7
+      - name: Install project
+        run: uv sync --all-groups
+      - name: Build wheel
+        run: uv build --sdist
+      - name: Publish package to PyPI
+        run: uv publish

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -51,6 +51,6 @@ jobs:
           check-dir: '"check"'
       - name: artifacts
         if: ${{ matrix.config.r == 'release' && matrix.config.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: check

--- a/R/humanleague.R
+++ b/R/humanleague.R
@@ -9,7 +9,7 @@
 #' \itemize{
 #'  \item{Iterative Proportional Fitting (IPF), \emph{a la} \pkg{mipfp} package}
 #'  \item{\href{http://jasss.soc.surrey.ac.uk/20/4/14.html}{Quasirandom Integer Sampling (QIS)} (no seed population)}
-#'- \item{Quasirandom Integer Sampling of IPF (QISI): A combination of the two techniques whereby IPF solutions are used to sample an integer population.}
+#'  \item{Quasirandom Integer Sampling of IPF (QISI): A combination of the two techniques whereby IPF solutions are used to sample an integer population.}
 #'}
 #'
 #' The latter provides a bridge between deterministic reweighting and combinatorial optimisation, offering advantages of both techniques:
@@ -30,7 +30,7 @@
 #' The package also contains the following utility functions:
 #' \itemize{
 #'   \item{a Sobol sequence generator}
-#' - \item{functionality to convert fractional to nearest-integer marginals (in 1D). This can also be achieved in multiple dimensions by using the QISI algorithm.}
+#'   \item{functionality to convert fractional to nearest-integer marginals (in 1D). This can also be achieved in multiple dimensions by using the QISI algorithm.}
 #'   \item{functionality to 'flatten' a population into a table: this converts a multidimensional array containing the population count for each state into a table listing individuals and their characteristics.}
 #'}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanleague"
-version = "2.4.4"
+version = "2.4.5"
 authors = [
   { name="Andrew Smith", email="andrew@friarswood.net" },
 ]
@@ -25,19 +25,19 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy>=2.4.1",
-    "pandas>=2.3.3",
+    "numpy>=2.4.5",
+    "pandas>=3.0.3",
 ]
 
 [dependency-groups]
 dev = [
-  "pybind11>=3.0.0",
-  "pytest>=8.1.4",
-  "ruff>=0.12.9",
-  "build>=1.2.2.post1",
-  "ty>=0.0.31",
-  "pre-commit>=4.5.1",
-  "pandas-stubs>=2.2.3.250308",
+  "pybind11>=3.0.4",
+  "pytest>=9.0.3",
+  "ruff>=0.15.13",
+  "build>=1.5.0",
+  "ty>=0.0.37",
+  "pre-commit>=4.6.0",
+  "pandas-stubs>=3.0.0.260204",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 dependencies = [
     "numpy>=2.4.1",
     "pandas>=2.3.3",
-    "pandas-stubs>=2.2.3.250308",
 ]
 
 [dependency-groups]
@@ -38,6 +37,7 @@ dev = [
   "build>=1.2.2.post1",
   "ty>=0.0.31",
   "pre-commit>=4.5.1",
+  "pandas-stubs>=2.2.3.250308",
 ]
 
 [tool.pytest.ini_options]

--- a/src/Log.h
+++ b/src/Log.h
@@ -12,7 +12,7 @@ template <typename T> std::string to_string_impl(T v) { return std::to_string(v)
 // print pointer
 template <typename T> std::string to_string_impl(T* p) {
   constexpr size_t BUF_SIZE = 20;
-  static char buf[BUF_SIZE];
+  char buf[BUF_SIZE];
   std::snprintf(buf, BUF_SIZE, "0x%016zx", reinterpret_cast<size_t>(p));
   return std::string(buf);
 }

--- a/src/NDArrayUtils.h
+++ b/src/NDArrayUtils.h
@@ -39,11 +39,11 @@ template <typename T> T min(const NDArray<T>& a) {
 }
 
 template <typename T> T max(const NDArray<T>& a) {
-  T minVal = std::numeric_limits<T>::max();
+  T maxVal = std::numeric_limits<T>::lowest();
   for (Index i(a.sizes()); !i.end(); ++i) {
-    minVal = std::min(minVal, a[i]);
+    maxVal = std::max(maxVal, a[i]);
   }
-  return minVal;
+  return maxVal;
 }
 
 // TODO move printing somehwere else

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -65,8 +65,9 @@ template <typename T> NDArray<T> asNDArray(const py::array_t<T>& np) {
 }
 
 template <typename T> py::array_t<T> fromNDArray(const NDArray<T>& a) {
-  // TODO ensure this is safe. may need to explicitly copy data
-  return py::array_t<T>(a.sizes(), a.rawData());
+  py::array_t<T> result(a.sizes());
+  std::copy(a.rawData(), a.rawData() + a.storageSize(), result.mutable_data());
+  return result;
 }
 
 std::vector<std::vector<int64_t>> collect_indices(const py::iterable& iterable) {

--- a/src/rcpp_api.cpp
+++ b/src/rcpp_api.cpp
@@ -127,9 +127,6 @@ List ipf(NumericVector seed, List indices, List marginals) {
   std::vector<int64_t> s;
   s.reserve(dim);
 
-  if (indices.size() != marginals.size())
-    throw std::runtime_error("no. of marginals not equal to no. of indices");
-
   // assemble dimensions (row major) for seed
   for (int64_t i = dim - 1; i >= 0; --i)
     s.push_back(rSizes[(size_t)i]);
@@ -202,9 +199,6 @@ List qis(List indices, List marginals, int skips = 0) {
   m.reserve(k);
   std::vector<std::vector<int64_t>> idx;
   idx.reserve(k);
-
-  if (indices.size() != marginals.size())
-    throw std::runtime_error("no. of marginals not equal to no. of indices");
 
   // insert indices and marginals in reverse order (R being column-major)
   for (int64_t i = k - 1; i >= 0; --i) {
@@ -287,9 +281,6 @@ List qisi(NumericVector seed, List indices, List marginals, int skips = 0) {
   idx.reserve(k);
   std::vector<int64_t> s;
   s.reserve(dim);
-
-  if (indices.size() != marginals.size())
-    throw std::runtime_error("no. of marginals not equal to no. of indices");
 
   // assemble dimensions (row major) for seed
   for (int64_t i = dim - 1; i >= 0; --i)


### PR DESCRIPTION
## Summary

- **`NDArrayUtils.h`**: `max()` was computing the minimum due to a copy-paste error from `min()` — used `std::min` and `std::numeric_limits<T>::max()` (sentinel for a minimum search). Fixed to use `std::numeric_limits<T>::lowest()` and `std::max`.
- **`module.cpp`**: `fromNDArray()` returned a non-owning numpy view into an NDArray whose lifetime ends at the return site, causing a potential use-after-free. Now allocates an owning array and explicitly copies the data.
- **`rcpp_api.cpp`**: Removed duplicate `indices.size() != marginals.size()` checks in `ipf()`, `qis()`, and `qisi()` — each had the same check twice, with the second being dead code.
- **`Log.h`**: Removed `static` from the local `char buf[]` in `to_string_impl<T*>` to eliminate shared mutable state across calls (not thread-safe).
- **`humanleague.R`**: Fixed two malformed Roxygen `\itemize` entries where a stray `-` outside `\item{}` would render incorrectly in the package documentation.
- **`pyproject.toml`**: Moved `pandas-stubs` from runtime `dependencies` to `[dependency-groups].dev` — it is a typing-only package not needed by end users.

## Test plan

- [ ] Run `uv run pytest` — Python test suite should pass unchanged (no logic changes to algorithms)
- [ ] Run `R CMD check` — Roxygen fix should produce clean docs; no R logic changed
- [ ] Verify `fromNDArray` fix: existing Python tests exercise all return paths (`qis`, `qisi`, `ipf`) and would catch memory corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)